### PR TITLE
Update python_version for 3.13

### DIFF
--- a/microsoftsccm.json
+++ b/microsoftsccm.json
@@ -19,7 +19,7 @@
     "latest_tested_versions": [
         "Microsoft SCCM v5.00.8412.1000"
     ],
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "app_wizard_version": "1.0.0",
     "configuration": {
         "server_url": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)